### PR TITLE
-i flag required for base64

### DIFF
--- a/build
+++ b/build
@@ -8,7 +8,7 @@ cp ./target/riscv64-kartoffel-bot/release/kartoffel-bot kartoffel
 if [[ "$1" == "--copy" ]]; then
     # Mac
     if [[ -x "$(command -v pbcopy)" ]]; then
-        base64 kartoffel | pbcopy
+        base64 -i kartoffel | pbcopy
         exit
     fi
 


### PR DESCRIPTION
I get the following error when running `./build` on Mac:

```
/build --copy
    Finished `release` profile [optimized] target(s) in 0.06s
base64: invalid argument kartoffel
Usage:	base64 [-hDd] [-b num] [-i in_file] [-o out_file]
  -h, --help     display this message
  -Dd, --decode   decodes input
  -b, --break    break encoded string into num character lines
  -i, --input    input file (default: "-" for stdin)
  -o, --output   output file (default: "-" for stdout)
  ```
  
  Using the usage defined there, it looks like adding the -i flag fixes it. This seems to fix the problem for me locally