### PR TITLE
Made "./build --copy" work for wsl

### DIFF
--- a/build
+++ b/build
@@ -12,6 +12,12 @@ if [[ "$1" == "--copy" ]]; then
         exit
     fi
 
+    # WSL
+    if [[ -x "$(command -v clip.exe)" ]]; then
+        base64 kartoffel | clip.exe
+        exit
+    fi
+
     # Wayland
     if [[ -x "$(command -v wl-copy)" ]]; then
         base64 kartoffel | wl-copy


### PR DESCRIPTION
Added usage of `clip.exe` for wsl (and maybe windows I guess).