### PR TITLE
fix(build): respect `CARGO_BUILD_TARGET_DIR`

### DIFF
--- a/build
+++ b/build
@@ -3,7 +3,7 @@
 set -e
 
 cargo build --release
-cp ./target/riscv64-kartoffel-bot/release/kartoffel-bot kartoffel
+cp "${CARGO_BUILD_TARGET_DIR:-./target}/riscv64-kartoffel-bot/release/kartoffel-bot" kartoffel
 
 if [[ "$1" == "--copy" ]]; then
     # Mac


### PR DESCRIPTION
if `CARGO_BUILD_TARGET_DIR` is set then copy binary from cargo build target dir