### PR TITLE
fix(build): add build script dependencies to flake devShell

### DIFF
--- a/build
+++ b/build
@@ -19,7 +19,7 @@ if [[ "$1" == "--copy" ]]; then
     fi
 
     # Wayland
-    if [[ -x "$(command -v wl-copy)" ]]; then
+    if [[ -x "$(command -v wl-copy)" && ( "$XDG_SESSION_TYPE" == "wayland" || -z ${WAYLAND_DISPLAY} ) ]]; then
         base64 kartoffel | wl-copy
         exit
     fi

--- a/flake.nix
+++ b/flake.nix
@@ -42,6 +42,12 @@
       in
       {
         devShell = pkgs.mkShell {
+          packages = with pkgs; [
+            coreutils
+            curl
+            xclip
+            wl-clipboard
+          ];
           nativeBuildInputs = [
             toolchain
           ];


### PR DESCRIPTION
First things first - big thanks from a Nix user for adding a flake! Saved me a couple minutes of extra setup.

This adds the `coreutils`, `curl`, `xclip`, and `wl-clipboard` packages to the default devShell so that the build script can be run without any system dependencies. This can be replicated in a test environment by running:
```sh
nix develop -i -k XDG_RUNTIME_DIR -k WAYLAND_DISPLAY # on wayland
```
or
```sh
nix develop -i -k XAUTHORITY -k DISPLAY -c ./build --copy # on Xorg
```